### PR TITLE
Add Hermes AI agent Docker Compose configuration

### DIFF
--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -16,10 +16,10 @@ services:
     #   - "9119:9119" # dashboard (only reached when HERMES_DASHBOARD=1)
     environment:
       HERMES_DASHBOARD: "1"
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
       # Uncomment to forward specific env vars instead of using ~/.hermes/.env:
       # ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       # OPENAI_API_KEY: ${OPENAI_API_KEY}
-      # TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
     volumes:
       - hermes:/opt/data
     deploy:

--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -1,0 +1,45 @@
+---
+networks:
+  proxy:
+    external: true
+
+volumes:
+  hermes:
+
+services:
+  hermes:
+    container_name: hermes
+    image: nousresearch/hermes-agent:latest
+    command: gateway run
+    # ports:
+    #   - "8642:8642" # gateway API
+    #   - "9119:9119" # dashboard (only reached when HERMES_DASHBOARD=1)
+    environment:
+      HERMES_DASHBOARD: "1"
+      # Uncomment to forward specific env vars instead of using ~/.hermes/.env:
+      # ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # OPENAI_API_KEY: ${OPENAI_API_KEY}
+      # TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+    volumes:
+      - hermes:/opt/data
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.hermes.entrypoints=http
+      - traefik.http.routers.hermes.rule=Host(`hermes.${DOMAIN}`)
+      - traefik.http.routers.hermes-secure.entrypoints=https
+      - traefik.http.routers.hermes-secure.rule=Host(`hermes.${DOMAIN}`)
+      - traefik.http.routers.hermes-secure.tls=true
+      - traefik.http.routers.hermes-secure.tls.certresolver=cloudflare
+      - traefik.http.routers.hermes-secure.service=hermes
+      - traefik.http.services.hermes.loadbalancer.server.port=9119
+    networks:
+      - proxy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true

--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -9,7 +9,7 @@ volumes:
 services:
   hermes:
     container_name: hermes
-    image: nousresearch/hermes-agent:latest
+    image: nousresearch/hermes-agent:v2026.6.19
     command: gateway run
     # ports:
     #   - "8642:8642" # gateway API


### PR DESCRIPTION
## Summary
This PR adds a Docker Compose configuration for deploying the Hermes AI agent service, a gateway-based agent from Nous Research.

## Key Changes
- Added `docker-apps/ai/hermes/docker-compose.yaml` with complete service configuration
- Configured Hermes agent container with:
  - Image: `nousresearch/hermes-agent:v2026.6.19`
  - Gateway mode operation
  - Dashboard enabled for monitoring
  - Telegram bot integration via environment variable
  - Persistent data volume at `/opt/data`
- Set resource limits: 4GB memory and 2.0 CPU cores
- Integrated with Traefik reverse proxy for HTTP/HTTPS routing
- Configured SSL/TLS with Cloudflare certificate resolver
- Connected to external `proxy` network for service communication
- Added security hardening with `no-new-privileges` option
- Configured automatic restart policy

## Notable Implementation Details
- Dashboard accessible on port 9119 (commented out direct port exposure in favor of Traefik routing)
- Gateway API available on port 8642 (commented out)
- Environment variables support for API keys (Anthropic, OpenAI) with fallback to `~/.hermes/.env`
- Service accessible via `hermes.${DOMAIN}` subdomain with automatic HTTPS

https://claude.ai/code/session_0181r1fnaorxaTm76a2jPkNz