### PR TITLE
Use environment variable for Immich version instead of hardcoded tag

### DIFF
--- a/docker-apps/storage/immich/docker-compose.yaml
+++ b/docker-apps/storage/immich/docker-compose.yaml
@@ -10,7 +10,7 @@ volumes:
 services:
   immich-server:
     container_name: immich_server
-    image: ghcr.io/immich-app/immich-server:v2.7.5
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     volumes:
@@ -50,7 +50,7 @@ services:
     container_name: immich_machine_learning
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
-    image: ghcr.io/immich-app/immich-machine-learning:v2.7.5
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
     # extends: # uncomment this section for hardware acceleration - see https://immich.app/docs/features/ml-hardware-acceleration
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable


### PR DESCRIPTION
## Summary
Updated the Immich Docker Compose configuration to use an environment variable for specifying the container image version instead of hardcoding a specific version tag.

## Key Changes
- Replaced hardcoded `v2.7.5` tag with `${IMMICH_VERSION:-release}` environment variable for both `immich-server` and `immich-machine-learning` services
- This allows users to easily override the version at deployment time without modifying the compose file
- Falls back to `release` tag if the `IMMICH_VERSION` environment variable is not set

## Benefits
- Improved flexibility for version management across different deployment environments
- Easier updates and rollbacks by changing an environment variable
- Aligns with the pattern already suggested in the comments for hardware acceleration configuration

https://claude.ai/code/session_017nw4NDTk17kLkQ2gM2SFbs