### PR TITLE
Make Hermes compose multi-instance (run several agents per host)

### DIFF
--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -1,19 +1,31 @@
 ---
+# Hermes agent — instance-templated so the SAME file can run multiple agents
+# on one host without collisions.
+#
+# Everything that must be unique per agent is derived from ${HERMES_INSTANCE}:
+# the container name, the Traefik router/service names, the per-agent hostnames
+# and (via ${WORKDIR}) the data directory. Deploy each agent as its own Compose
+# project so they never share state:
+#
+#   HERMES_INSTANCE=1 WORKDIR=/…/hermes-1 docker compose -p hermes-1 up -d
+#   HERMES_INSTANCE=2 WORKDIR=/…/hermes-2 docker compose -p hermes-2 up -d
+#
+# The Ansible play (homelab: ansible/playbooks/rpi-4.yml) loops over
+# `hermes_instances` and sets these for you.
+#
+# No host ports are published — each agent is reached only through Traefik, as
+# the rpi-4 play documents. Both surfaces get their own per-instance hostname:
+#   - dashboard   -> hermes-${HERMES_INSTANCE}.${DOMAIN}     (port 9119)
+#   - gateway API -> hermes-${HERMES_INSTANCE}-gw.${DOMAIN}  (port 8642)
 networks:
   proxy:
     external: true
 
-volumes:
-  hermes:
-
 services:
   hermes:
-    container_name: hermes
+    container_name: hermes-${HERMES_INSTANCE}
     image: nousresearch/hermes-agent:v2026.7.1
     command: gateway run
-    ports:
-      - "8642:8642" # gateway API
-      - "9119:9119" # dashboard (only reached when HERMES_DASHBOARD=1)
     environment:
       HERMES_DASHBOARD: "1"
       HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "${HERMES_DASHBOARD_BASIC_AUTH_USERNAME}"
@@ -24,19 +36,34 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
-          cpus: "2.0"
+          # Lower these per instance so several agents fit on one Pi; the
+          # defaults preserve the original single-agent budget (4G / 2 CPU).
+          memory: ${HERMES_MEM_LIMIT:-4G}
+          cpus: "${HERMES_CPU_LIMIT:-2.0}"
     labels:
       - traefik.enable=true
       - traefik.docker.network=proxy
-      - traefik.http.routers.hermes.entrypoints=http
-      - traefik.http.routers.hermes.rule=Host(`hermes.${DOMAIN}`)
-      - traefik.http.routers.hermes-secure.entrypoints=https
-      - traefik.http.routers.hermes-secure.rule=Host(`hermes.${DOMAIN}`)
-      - traefik.http.routers.hermes-secure.tls=true
-      - traefik.http.routers.hermes-secure.tls.certresolver=cloudflare
-      - traefik.http.routers.hermes-secure.service=hermes
-      - traefik.http.services.hermes.loadbalancer.server.port=9119
+      # --- dashboard (port 9119) ---
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash.entrypoints=http
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash.rule=Host(`hermes-${HERMES_INSTANCE}.${DOMAIN}`)
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.entrypoints=https
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.rule=Host(`hermes-${HERMES_INSTANCE}.${DOMAIN}`)
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.tls=true
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.tls.certresolver=cloudflare
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.service=hermes-${HERMES_INSTANCE}-dashboard
+      - traefik.http.services.hermes-${HERMES_INSTANCE}-dashboard.loadbalancer.server.port=9119
+      # --- gateway API (port 8642) ---
+      # Replaces the old host-published 8642. The gateway has no auth of its
+      # own, so add a Traefik basicauth middleware before exposing it beyond the
+      # trusted network.
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.entrypoints=http
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.entrypoints=https
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls=true
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls.certresolver=cloudflare
+      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.service=hermes-${HERMES_INSTANCE}-gateway
+      - traefik.http.services.hermes-${HERMES_INSTANCE}-gateway.loadbalancer.server.port=8642
     networks:
       - proxy
     restart: unless-stopped

--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -14,9 +14,10 @@
 # `hermes_instances` and sets these for you.
 #
 # No host ports are published — each agent is reached only through Traefik, as
-# the rpi-4 play documents. Both surfaces get their own per-instance hostname:
+# the rpi-4 play documents:
 #   - dashboard   -> hermes-${HERMES_INSTANCE}.${DOMAIN}     (port 9119)
-#   - gateway API -> hermes-${HERMES_INSTANCE}-gw.${DOMAIN}  (port 8642)
+#   - gateway API -> port 8642, disabled by default (see the labels block for
+#     what it's for and how to enable it)
 networks:
   proxy:
     external: true
@@ -52,18 +53,25 @@ services:
       - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.tls.certresolver=cloudflare
       - traefik.http.routers.hermes-${HERMES_INSTANCE}-dash-secure.service=hermes-${HERMES_INSTANCE}-dashboard
       - traefik.http.services.hermes-${HERMES_INSTANCE}-dashboard.loadbalancer.server.port=9119
-      # --- gateway API (port 8642) ---
-      # Replaces the old host-published 8642. The gateway has no auth of its
-      # own, so add a Traefik basicauth middleware before exposing it beyond the
-      # trusted network.
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.entrypoints=http
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.entrypoints=https
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls=true
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls.certresolver=cloudflare
-      - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.service=hermes-${HERMES_INSTANCE}-gateway
-      - traefik.http.services.hermes-${HERMES_INSTANCE}-gateway.loadbalancer.server.port=8642
+      # --- gateway API (port 8642) — DISABLED for now ---
+      # The gateway API is the machine-to-machine HTTP control plane: how OTHER
+      # software drives the agent (POST tasks/messages, wire up another service,
+      # automation scripts). It is NOT needed for the dashboard or the Telegram
+      # bot — the bot talks to Telegram over outbound connections, so nothing
+      # reaches the agent through this port. Left disabled to avoid exposing an
+      # unauthenticated surface.
+      #
+      # To enable: uncomment the routes below and add a Traefik basicauth
+      # middleware first (the gateway has no auth of its own), then the API is
+      # reachable at hermes-${HERMES_INSTANCE}-gw.${DOMAIN}.
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.entrypoints=http
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.entrypoints=https
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.rule=Host(`hermes-${HERMES_INSTANCE}-gw.${DOMAIN}`)
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls=true
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.tls.certresolver=cloudflare
+      # - traefik.http.routers.hermes-${HERMES_INSTANCE}-gw-secure.service=hermes-${HERMES_INSTANCE}-gateway
+      # - traefik.http.services.hermes-${HERMES_INSTANCE}-gateway.loadbalancer.server.port=8642
     networks:
       - proxy
     restart: unless-stopped

--- a/docker-apps/ai/hermes/docker-compose.yaml
+++ b/docker-apps/ai/hermes/docker-compose.yaml
@@ -7,11 +7,11 @@
 # and (via ${WORKDIR}) the data directory. Deploy each agent as its own Compose
 # project so they never share state:
 #
-#   HERMES_INSTANCE=1 WORKDIR=/…/hermes-1 docker compose -p hermes-1 up -d
-#   HERMES_INSTANCE=2 WORKDIR=/…/hermes-2 docker compose -p hermes-2 up -d
+#   HERMES_INSTANCE=angel WORKDIR=/…/hermes-angel docker compose -p hermes-angel up -d
+#   HERMES_INSTANCE=marta WORKDIR=/…/hermes-marta docker compose -p hermes-marta up -d
 #
-# The Ansible play (homelab: ansible/playbooks/rpi-4.yml) loops over
-# `hermes_instances` and sets these for you.
+# The Ansible plays (homelab: ansible/playbooks/rpi-4.yml) define each agent
+# individually and set these for you.
 #
 # No host ports are published — each agent is reached only through Traefik, as
 # the rpi-4 play documents:


### PR DESCRIPTION
## Why

Today `docker-apps/ai/hermes/docker-compose.yaml` is a strict **singleton**, so a second copy on the same host collides on the fixed `container_name`, the published host ports `8642`/`9119`, the Traefik router/service names, and the single `hermes.${DOMAIN}` hostname — and re-running from the same directory just reconciles the one container (same Compose project). This makes it impossible to run multiple Hermes agents on the Pi.

## What changed

The compose file is now **instance-templated**, keyed on `${HERMES_INSTANCE}`, so the same file can be deployed as N independent Compose projects with zero collisions:

- `container_name: hermes-${HERMES_INSTANCE}`
- Per-instance Traefik router/service names and hostname
- Memory/CPU caps templated (`${HERMES_MEM_LIMIT:-4G}` / `${HERMES_CPU_LIMIT:-2.0}`) so several agents can be sized to fit one Pi; **defaults preserve the original single-agent budget**
- Removed the unused named-volume declaration (`/opt/data` was always a `${WORKDIR}` bind mount)

`${HERMES_INSTANCE}` is any string — the companion **homelab** PR #18 deploys two named agents, `angel` and `marta`, each set individually (`ansible/playbooks/rpi-4.yml`).

## Access model

- **Host ports removed.** The old file published `8642`/`9119` on the host, but the `rpi-4` play already documents *"Hermes publishes no host ports; it is only reachable through Traefik."* This aligns the file with that intent and removes the port collision.
- **Dashboard** (port 9119) → `hermes-<instance>.${DOMAIN}`, per agent. This is the only surface exposed.
- **Gateway API** (port 8642) → the machine-to-machine control plane for driving the agent from other software. It is **not** used by the dashboard or the Telegram bot (the bot talks to Telegram over outbound connections), so its Traefik routes are **left commented out** rather than exposing an unauthenticated surface. What it's for and how to enable it (uncomment + add a basicauth middleware) is documented inline in the labels block.

## Validation

`docker compose config` passes for every file via the exact `compose-lint` loop. Rendering named instances confirms fully disjoint identifiers (container name, hostname, router/service names) and that only the dashboard route is emitted. Deploy-time variables come from the homelab play.